### PR TITLE
fix(ui): correct password visibility toggle logic on Sign Up page

### DIFF
--- a/backend/utils/password.js
+++ b/backend/utils/password.js
@@ -17,12 +17,12 @@ const comparePassword = async (password, hashedPassword) => {
   }
 };
 
-const validatePasswordStrength = (password) => {
+const validatePasswordStrength = password => {
   const isValid =
     password.length >= 8 &&
-    /[a-z]/.test(password) &&      // at least one lowercase
-    /[A-Z]/.test(password) &&      // at least one uppercase
-    /\d/.test(password) &&         // at least one number
+    /[a-z]/.test(password) && // at least one lowercase
+    /[A-Z]/.test(password) && // at least one uppercase
+    /\d/.test(password) && // at least one number
     /[!@#$%^&*(),.?":{}|<>]/.test(password); // at least one special character
 
   return {
@@ -36,5 +36,5 @@ const validatePasswordStrength = (password) => {
 module.exports = {
   hashPassword,
   comparePassword,
-  validatePasswordStrength
+  validatePasswordStrength,
 };

--- a/frontend/app/landingpage/components/Automation.tsx
+++ b/frontend/app/landingpage/components/Automation.tsx
@@ -213,7 +213,7 @@ export default function Automation() {
             transition={{ duration: 1, delay: 0.4, ease: 'easeOut' }}
             className="text-xl text-slate-300 max-w-3xl mx-auto"
           >
-            Build intelligent automation workflows that adapt to your team's
+            Build intelligent automation workflows that adapt to your team&apos;s
             needs. From simple notifications to complex multi-step processes,
             Nexara makes automation accessible to everyone.
           </motion.p>

--- a/frontend/app/landingpage/components/CTA.tsx
+++ b/frontend/app/landingpage/components/CTA.tsx
@@ -385,7 +385,7 @@ export default function CTA() {
               </motion.h3>
               <p className="text-slate-300 mb-6 max-w-2xl mx-auto">
                 Our team is here to help you get started and make the most of
-                Nexara's powerful features.
+                Nexara&pos;s powerful features.
               </p>
               <div className="flex flex-col sm:flex-row gap-4 justify-center">
                 <motion.div

--- a/frontend/app/landingpage/components/Hero.tsx
+++ b/frontend/app/landingpage/components/Hero.tsx
@@ -160,7 +160,7 @@ export default function Hero() {
           transition={{ duration: 1, delay: 0.5, ease: 'easeOut' }}
           className="text-xl md:text-2xl text-slate-300 mb-8 max-w-4xl mx-auto leading-relaxed"
         >
-          Nexara combines Jira's powerful project management with AI-driven
+          Nexara combines Jira&pos;s powerful project management with AI-driven
           automation, intelligent insights, and seamless integrations. Build,
           track, and deliver projects faster than ever.
         </motion.p>

--- a/frontend/app/landingpage/components/Integrations.tsx
+++ b/frontend/app/landingpage/components/Integrations.tsx
@@ -138,7 +138,7 @@ export default function Integrations() {
             transition={{ duration: 0.6, delay: 0.4 }}
             className="text-xl text-slate-300 max-w-3xl mx-auto"
           >
-            Nexara's MCP server seamlessly integrates with your existing
+            Nexara&pos;s MCP server seamlessly integrates with your existing
             workflow. Connect Slack, GitHub, Figma, and hundreds more to create
             a unified project management experience.
           </motion.p>
@@ -246,7 +246,7 @@ export default function Integrations() {
               How integrations work
             </h3>
             <p className="text-slate-300 max-w-2xl mx-auto">
-              Setting up integrations is simple and secure. Here's how it works:
+              Setting up integrations is simple and secure. Here&pos;s how it works:
             </p>
           </div>
 

--- a/frontend/app/landingpage/components/Testimonials.tsx
+++ b/frontend/app/landingpage/components/Testimonials.tsx
@@ -174,7 +174,7 @@ export default function Testimonials() {
                 </CardHeader>
                 <CardContent>
                   <CardDescription className="text-slate-300 text-base leading-relaxed mb-4">
-                    "{testimonial.content}"
+                    &quot;{testimonial.content}&quot;
                   </CardDescription>
                   <div>
                     <div className="font-semibold text-white">

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -227,7 +227,7 @@ export default function LoginPage() {
 
                 <div className="text-center">
                   <p className="text-slate-400 text-sm">
-                    Don't have an account?{' '}
+                    Don&pos;t have an account?{' '}
                     <Link
                       href="/signup"
                       className="text-cyan-400 hover:text-cyan-300 font-medium transition-colors duration-200"

--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -254,7 +254,6 @@ export default function SignupPage() {
                         <Eye className="w-4 h-4" />
                       ) : (
                         <EyeOff className="w-4 h-4" />
-                        
                       )}
                     </Button>
                   </div>
@@ -292,7 +291,6 @@ export default function SignupPage() {
                       {showConfirmPassword ? (
                         <Eye className="w-4 h-4" />
                       ) : (
-                        
                         <EyeOff className="w-4 h-4" />
                       )}
                     </Button>

--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -25,8 +25,8 @@ import {
 } from 'lucide-react'
 
 export default function SignupPage() {
-  const [showPassword, setShowPassword] = useState(true)
-  const [showConfirmPassword, setShowConfirmPassword] = useState(true)
+  const [showPassword, setShowPassword] = useState(false)
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false)
   const [formData, setFormData] = useState({
     firstName: '',
     lastName: '',

--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -25,8 +25,8 @@ import {
 } from 'lucide-react'
 
 export default function SignupPage() {
-  const [showPassword, setShowPassword] = useState(false)
-  const [showConfirmPassword, setShowConfirmPassword] = useState(false)
+  const [showPassword, setShowPassword] = useState(true)
+  const [showConfirmPassword, setShowConfirmPassword] = useState(true)
   const [formData, setFormData] = useState({
     firstName: '',
     lastName: '',
@@ -251,9 +251,10 @@ export default function SignupPage() {
                       onClick={() => setShowPassword(!showPassword)}
                     >
                       {showPassword ? (
-                        <EyeOff className="w-4 h-4" />
-                      ) : (
                         <Eye className="w-4 h-4" />
+                      ) : (
+                        <EyeOff className="w-4 h-4" />
+                        
                       )}
                     </Button>
                   </div>
@@ -289,9 +290,10 @@ export default function SignupPage() {
                       }
                     >
                       {showConfirmPassword ? (
-                        <EyeOff className="w-4 h-4" />
-                      ) : (
                         <Eye className="w-4 h-4" />
+                      ) : (
+                        
+                        <EyeOff className="w-4 h-4" />
                       )}
                     </Button>
                   </div>


### PR DESCRIPTION
level 1

On the Sign Up page, the password visibility (eye) icon worked in reverse:
Eye open → password hidden 
Eye closed → password visible 

Expected Behavior
Eye open → password visible 
Eye closed → password hidden 

Fix Implemented

Corrected toggle logic

Video Link: [https://youtu.be/Y8FuLygGURc](url)


